### PR TITLE
PFW-1056: Use timer4 as Tone timer

### DIFF
--- a/IDE_Board_Manager/prusa3drambo-1.0.1/cores/rambo/Tone.cpp
+++ b/IDE_Board_Manager/prusa3drambo-1.0.1/cores/rambo/Tone.cpp
@@ -91,9 +91,9 @@ volatile uint8_t timer5_pin_mask;
 #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
 
 #define AVAILABLE_TONE_PINS 1
-#define USE_TIMER2
+#define USE_TIMER4
 
-const uint8_t PROGMEM tone_pin_to_timer_PGM[] = { 2 /*, 3, 4, 5, 1, 0 */ };
+const uint8_t PROGMEM tone_pin_to_timer_PGM[] = { 4 /*, 3, 5 */ };
 static uint8_t tone_pins[AVAILABLE_TONE_PINS] = { 255 /*, 255, 255, 255, 255, 255 */ };
 
 #elif defined(__AVR_ATmega8__)


### PR DESCRIPTION
@DRracer This PR changes the timer used on the Rambo boards from timer2 to timer4 since timer2 is system_timer now. I tested it on the miniRambo and it works as expected. I'll also make a PR on Prusa-Firmware if this gets merged where tone is re-enabled. I didn't create the release archive as of yet in case you want some changes to this.

BTW I chose timer4 since it is a timer that is free on both rambo boards, unlike the other commented timers. See discussion here: https://github.com/prusa3d/Prusa-Firmware/issues/1995#issuecomment-516173791