### PR TITLE
Reduce warnings when using gcc 7+

### DIFF
--- a/IDE_Board_Manager/prusa3dboards/platform.txt
+++ b/IDE_Board_Manager/prusa3dboards/platform.txt
@@ -15,7 +15,7 @@ compiler.warning_flags=-w
 compiler.warning_flags.none=-w
 compiler.warning_flags.default=
 compiler.warning_flags.more=-Wall
-compiler.warning_flags.all=-Wall -Wextra
+compiler.warning_flags.all=-Wall -Wextra -Wno-expansion-to-defined
 
 # Default "compiler.path" is correct, change only if you want to override the initial value
 compiler.path={runtime.tools.avr-gcc.path}/bin/


### PR DESCRIPTION
Add -Wno-expansion-to-defined to remove unneeded portability warnings
when using recent versions of gcc.

It should only be merged if the build environment is updated as well.

The flag is not available on gcc 4 (as used in the current
PF-build-env). It doesn't cause a build failure, but generates an
additional warning for each compilation, which is not ideal.