### PR TITLE
Rework compiler/linker flags

### DIFF
--- a/IDE_Board_Manager/prusa3dboards/platform.txt
+++ b/IDE_Board_Manager/prusa3dboards/platform.txt
@@ -21,11 +21,11 @@ compiler.warning_flags.all=-Wall -Wextra
 compiler.path={runtime.tools.avr-gcc.path}/bin/
 compiler.c.cmd=avr-gcc
 compiler.c.flags=-c -g -Os {compiler.warning_flags} -std=gnu11 -ffunction-sections -fdata-sections -MMD -flto -fno-fat-lto-objects
-compiler.c.elf.flags={compiler.warning_flags} -Os -g -flto -fuse-linker-plugin -Wl,--gc-sections
+compiler.c.elf.flags=-Os -g -flto -Wl,--gc-sections
 compiler.c.elf.cmd=avr-gcc
 compiler.S.flags=-c -g -x assembler-with-cpp -flto -MMD
 compiler.cpp.cmd=avr-g++
-compiler.cpp.flags=-c -g -Os {compiler.warning_flags} -std=gnu++11 -fpermissive -fno-exceptions -ffunction-sections -fdata-sections -fno-threadsafe-statics -MMD -flto
+compiler.cpp.flags=-c -g -Os {compiler.warning_flags} -std=gnu++11 -ffunction-sections -fdata-sections -MMD -flto -fno-fat-lto-objects -fno-exceptions -fno-threadsafe-statics -fno-rtti
 compiler.ar.cmd=avr-gcc-ar
 compiler.ar.flags=rcs
 compiler.objcopy.cmd=avr-objcopy


### PR DESCRIPTION
- Remove unnecessary warning flags during linking stage
- Remove -fuse-linker-plugin, implied by -flto at link time
- Remove -fpermissive to avoid future warning creep (depends on https://github.com/prusa3d/Prusa-Firmware/pull/2405)
- Add -fno-rtti for c++ (no savings, just to avoid future usage of rtti)